### PR TITLE
Fix no-profiling on Bash older than 4.4

### DIFF
--- a/ETL/dynamodb-etl.sh
+++ b/ETL/dynamodb-etl.sh
@@ -231,11 +231,11 @@ scan() {
 	if [[ $# -eq 1 ]]; then
 		aws dynamodb scan --output json --table-name "$TABLE" --max-items "$MAX_ITEMS" \
 			"${SEGMENTATION[@]}" --starting-token "$1" \
-			"${PROFILING_SCAN[@]}"
+			${PROFILING_SCAN[@]+"${PROFILING_SCAN[@]}"}
 	else
 		aws dynamodb scan --output json --table-name "$TABLE" --max-items "$MAX_ITEMS" \
 			"${SEGMENTATION[@]}" \
-			"${PROFILING_SCAN[@]}"
+			${PROFILING_SCAN[@]+"${PROFILING_SCAN[@]}"}
 	fi
 	profiling -n "$(since "$t1"),"
 }

--- a/ETL/t/helper.sh
+++ b/ETL/t/helper.sh
@@ -3,6 +3,16 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+type mapfile >/dev/null 2>&1 || {
+	mapfile() {
+		local line
+		MAPFILE=( )
+		while IFS= read -r line; do
+			MAPFILE+=("$line")
+		done
+	}
+}
+
 # Test helper functions
 
 clearData() {
@@ -15,8 +25,8 @@ addData() {
 	if [[ "${#MAPFILE[@]}" -eq 0 ]]; then
 		FILE="00.json"
 	else
-		LAST="${MAPFILE[-1]%.json}"
-		[[ "${LAST}" == +([0-9]) ]] || { echo >&2 "Invalid data file: '${LAST}'"; return 1; }
+		LAST="${MAPFILE[$((${#MAPFILE[@]}-1))]%.json}"
+		[[ "${LAST}" =~ ([0-9]) ]] || { echo >&2 "Invalid data file: '${LAST}'"; return 1; }
 		FILE=$(printf "%02d.json" $((10#$LAST + 1)))
 	fi
 	cat > "${DATA}/${FILE}"
@@ -69,3 +79,4 @@ COUNTLINES
 chmod +x "${BIN}/countLines.sh"
 export PATH="${BIN}:${PATH}"
 
+# vim: set ts=2 sts=2 sw=2 tw=100 noet :


### PR DESCRIPTION
This also makes the testing compatible with bash 3.2, but the dynamodb
script itself is hopelessly incompatible with that. I do not have a
bash 4.3 to test dynamodb with, so no test was added for it.