### PR TITLE
Dcsobral/ch10797/add per worker output to dynamodb etl

### DIFF
--- a/ETL/dynamodb-etl.sh
+++ b/ETL/dynamodb-etl.sh
@@ -356,6 +356,8 @@ worker() {
 		WORKER_INFO="Worker #$WORKER: "
 	fi
 
+	trap 'showAborted' EXIT
+
 	if [[ -z $READ_FROM ]]; then
 		readData
 	else
@@ -364,6 +366,9 @@ worker() {
 		processData < "${FILE}"
 	fi
 
+	trap - EXIT
+
+	showFinished
 }
 
 scan() {
@@ -470,6 +475,18 @@ showEllapsed() {
 		estimate=$((TOTAL * duration / COUNT))
 		echo >&2 -n "Time ellapsed: $(showTimer $duration)"
 		echo >&2 " estimated: $(showTimer $estimate)"
+	fi
+}
+
+showFinished() {
+	if [[ -z $NO_TIMER && -z $QUIET && -n $ALL ]]; then
+		echo >&2 "${WORKER_INFO} Finished"
+	fi
+}
+
+showAborted() {
+	if [[ -z $NO_TIMER && -z $QUIET ]]; then
+		echo >&2 "${WORKER_INFO} *** ABORTED ***"
 	fi
 }
 

--- a/ETL/dynamodb-etl.sh
+++ b/ETL/dynamodb-etl.sh
@@ -246,11 +246,17 @@ main_stdout() {
 		echo >&5 "timestamp,wait,worker,send"
 	fi
 
+	if [[ $WORKERS -gt 1 ]]; then
+		OPT_TIMEOUT=("-t" "1")
+	else
+		OPT_TIMEOUT=( )
+	fi
+
 	t0=$(timestamp)
 	profiling -n "$(timestamp),"
 	while [[ ${#PIPE_FD[@]} -gt 0 ]]; do
 		for index in "${!PIPE_FD[@]}"; do
-			if read -r -t 1 -u "${PIPE_FD[$index]}" file; then
+			if read -r ${OPT_TIMEOUT[@]+"${OPT_TIMEOUT[@]}"} -u "${PIPE_FD[$index]}" file; then
 				profiling -n "$(since "$t0"),$index,"
 				t0=$(timestamp)
 				TMP_FILE="${WORKER_PARTIAL[$index]:-}$file"

--- a/ETL/dynamodb-etl.sh
+++ b/ETL/dynamodb-etl.sh
@@ -313,9 +313,11 @@ main_stdout() {
 main_pipe() {
 	for index in "${!PIPE_NAME[@]}"; do
 		if [[ -n $PIPE_TO ]]; then
-			CMD="$(printf "$PIPE_TO" $index)"
+			# shellcheck disable=SC2059
+			CMD="$(printf "$PIPE_TO" "$index")"
 		else
-			TMP="$(printf "$OUTPUT" $index)"
+			# shellcheck disable=SC2059
+			TMP="$(printf "$OUTPUT" "$index")"
 			CMD="cat > $TMP"
 		fi
 

--- a/ETL/dynamodb-etl.sh
+++ b/ETL/dynamodb-etl.sh
@@ -250,8 +250,13 @@ fi
 
 # Fetch total if using --all
 if [[ -n $ALL ]]; then
-	TOTAL="$(aws dynamodb describe-table --table-name "${TABLE}" | jq .Table.ItemCount)"
-	[[ -n $QUIET ]] || echo >&2 "Total ${TOTAL}"
+	if [[ -z $READ_FROM ]]; then
+		TOTAL="$(aws dynamodb describe-table --table-name "${TABLE}" | jq .Table.ItemCount)"
+		[[ -n $QUIET ]] || echo >&2 "Total ${TOTAL}"
+	else
+		FILES=( "${READ_FROM}"* )
+		TOTAL="${#FILES[@]}"
+	fi
 fi
 
 # Extra scan flags on verbose

--- a/ETL/t/aws.sh
+++ b/ETL/t/aws.sh
@@ -73,6 +73,10 @@ elif [[ -n $SCAN ]]; then
 	fi
 	POSITION=$((START + INDEX))
 	NEXT=$((INDEX + LENGTH))
+	if [[ $NEXT -gt $END ]]; then
+		LENGTH=$((LENGTH + END - NEXT))
+		NEXT=$END
+	fi
 	#echo >&2 "FILES ${#FILES[@]} SEGMENT $SEGMENT SEGMENTS $SEGMENTS PARTITION $PARTITION START $START END $END INDEX $INDEX POSITION $POSITION NEXT $NEXT"
 	cat "${FILES[@]:${POSITION}:${LENGTH}}" |
 		jq --slurp "{Items:.} | if $NEXT < $END then .+{NextToken:$NEXT} else . end" #| tee /dev/fd/2

--- a/ETL/t/aws.sh
+++ b/ETL/t/aws.sh
@@ -49,6 +49,12 @@ case "$1" in
 		echo >&2 "DESCRIBE_TABLE"
 		DESCRIBE_TABLE=1
 		;;
+	---segments-size)
+		shift
+		SEGMENTS_SIZE=( "$@" )
+		shift "${#SEGMENTS_SIZE[@]}"
+		echo >&2 "SEGMENTS_SIZE(${SEGMENTS_SIZE[*]})"
+		;;
 	*) shift ;;
 esac
 done
@@ -64,22 +70,29 @@ elif [[ -n $SCAN ]]; then
 	: "${LENGTH:=5}"
 	: "${SEGMENT:=0}"
 	: "${SEGMENTS:=1}"
-	PARTITION=$((${#FILES[@]} / SEGMENTS))
-	START=$((PARTITION * SEGMENT))
-	if [[ $((SEGMENT + 1)) -eq $SEGMENTS ]]; then
-		END="${#FILES[@]}"
+	if [[ -z "${SEGMENTS_SIZE[*]:-}" ]]; then
+		PARTITION=$((${#FILES[@]} / SEGMENTS))
+		START=$((PARTITION * SEGMENT))
+		if [[ $((SEGMENT + 1)) -eq $SEGMENTS ]]; then
+			END="${#FILES[@]}"
+		else
+			END=$((START + PARTITION))
+		fi
 	else
-		END=$((START + PARTITION))
+		START_SIZES=("${SEGMENTS_SIZE[@]:0:${SEGMENT}}")
+		# shellcheck disable=SC1102
+		START=$(("${START_SIZES[@]/%/+}" 0))
+		END=$((START + ${SEGMENTS_SIZE[$SEGMENT]}))
 	fi
 	POSITION=$((START + INDEX))
-	NEXT=$((INDEX + LENGTH))
-	if [[ $NEXT -gt $END ]]; then
-		LENGTH=$((LENGTH + END - NEXT))
-		NEXT=$END
+	REMAINING=$((END - POSITION))
+	if [[ $LENGTH -gt $REMAINING ]]; then
+		LENGTH="${REMAINING}"
 	fi
-	#echo >&2 "FILES ${#FILES[@]} SEGMENT $SEGMENT SEGMENTS $SEGMENTS PARTITION $PARTITION START $START END $END INDEX $INDEX POSITION $POSITION NEXT $NEXT"
+	NEXT=$((INDEX + LENGTH))
+	#echo >&2 "FILES ${#FILES[@]} SEGMENT $SEGMENT SEGMENTS $SEGMENTS PARTITION $PARTITION START $START LENGTH $LENGTH END $END REMAINING $REMAINING INDEX $INDEX POSITION $POSITION NEXT $NEXT"
 	cat "${FILES[@]:${POSITION}:${LENGTH}}" |
-		jq --slurp "{Items:.} | if $NEXT < $END then .+{NextToken:$NEXT} else . end" #| tee /dev/fd/2
+		jq --slurp "{Items:.} | if $LENGTH != $REMAINING then .+{NextToken:$NEXT} else . end" #| tee /dev/fd/2
 fi
 
 

--- a/ETL/t/dynamodb-etl.t
+++ b/ETL/t/dynamodb-etl.t
@@ -16,7 +16,7 @@ source "$(dirname "$0")/osht.sh"
 set +euo pipefail
 
 # Tests
-PLAN 127
+PLAN 132
 
 # Empty input for error tests
 clearData
@@ -289,5 +289,12 @@ RUNS grep -c '"mergedProjectData":{"a":"b"}' "${TMP}/worker_0_pipe"
 OGREP "20"
 RUNS grep -c '"mergedProjectData":{"a":"b"}' "${TMP}/worker_1_pipe"
 OGREP "20"
+
+# Unequal sized partitions CH10813
+RUNS "${SCRIPT}" --all --workers 2 --pipe "wc -l | tr -d ' ' > '${TMP}/partition%d'" ---segments-size 10 30 # Unequal sized partitions
+RUNS cat "${TMP}/partition0"
+ODIFF <<< $'10'
+RUNS cat "${TMP}/partition1"
+ODIFF <<< $'30'
 
 # vim: set ts=4 sw=4 sts=4 tw=100 noet filetype=sh :


### PR DESCRIPTION
Two new options:

`--output file` will send the output of each worker to "file". Use `%d` to distinguish between them.

`--pipe cmd` will pipe the output of each worker to a command, which may include pipes and redirects. Likewise, use %d to distinguish between them.

So instead of `dynamodb <parameters> | gzip -9 | aws s3 cp - ...`,  it is now possible to do `dynamodb <parameters> --pipe 'gzip -9 | aws s3 cp ...%d...`.

Output to stdout is still default, but the script will exit with an error if the bash version does not support that and multiple workers are used. An option `--stdout` was added as well for it.